### PR TITLE
Add quoteAssetPrecision field to exchangeInfo

### DIFF
--- a/rest-api.md
+++ b/rest-api.md
@@ -495,7 +495,8 @@ NONE
       "baseAsset": "ETH",
       "baseAssetPrecision": 8,
       "quoteAsset": "BTC",
-      "quotePrecision": 8,
+      "quotePrecision": 8, // will be removed in future api versions (v4+)
+      "quoteAssetPrecision": 8,
       "baseCommissionPrecision": 8,
       "quoteCommissionPrecision": 8,
       "orderTypes": [

--- a/rest-api_CN.md
+++ b/rest-api_CN.md
@@ -329,6 +329,7 @@ NONE
     "baseAssetPrecision": 8,
     "quoteAsset": "BTC",
     "quotePrecision": 8,
+    "quoteAssetPrecision": 8,
     "orderTypes": ["LIMIT", "MARKET"],
     "icebergAllowed": false,
     "filters": [{


### PR DESCRIPTION
Changed 2020-04-25 (https://binance-docs.github.io/apidocs/spot/en/#change-log)
Also listed in https://binance-docs.github.io/apidocs/spot/en/#exchange-information.

PR redirected from https://github.com/binance-exchange/binance-official-api-docs/pull/128