### PR TITLE
Specification for newClientOrderId

### DIFF
--- a/rest-api.md
+++ b/rest-api.md
@@ -914,7 +914,7 @@ timeInForce | ENUM | NO |
 quantity | DECIMAL | NO |
 quoteOrderQty|DECIMAL|NO|
 price | DECIMAL | NO |
-newClientOrderId | STRING | NO | A unique id among open orders. Automatically generated if not sent.<br> Orders with the same `newClientOrderID` can be accepted only when the previous one is filled, otherwise the order will be rejected.
+newClientOrderId | STRING | NO | A unique id among open orders. Automatically generated if not sent.<br> Orders with the same `newClientOrderID` can be accepted only when the previous one is filled, otherwise the order will be rejected.<br>If the string given contains a period (`.`) the order will also be rejected (code = 400, error = "Bad Request")
 stopPrice | DECIMAL | NO | Used with `STOP_LOSS`, `STOP_LOSS_LIMIT`, `TAKE_PROFIT`, and `TAKE_PROFIT_LIMIT` orders.
 icebergQty | DECIMAL | NO | Used with `LIMIT`, `STOP_LOSS_LIMIT`, and `TAKE_PROFIT_LIMIT` to create an iceberg order.
 newOrderRespType | ENUM | NO | Set the response JSON. `ACK`, `RESULT`, or `FULL`; `MARKET` and `LIMIT` order types default to `FULL`, all other orders default to `ACK`.


### PR DESCRIPTION
There's no valid reason I can see for `newClientOrderId` to be an rejected if it contains a period, but it does.
This is probably a bug, but I can't open an issue.
I didn't check for other characters are rejected, since I have other things to fight with with the binance API and the very friendly error reporting.