### PR TITLE
[Information Needed] - Document the "isWorking" field

### DIFF
--- a/rest-api.md
+++ b/rest-api.md
@@ -1066,6 +1066,7 @@ timestamp | LONG | YES |
 Notes:
 * Either `orderId` or `origClientOrderId` must be sent.
 * For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data is not available at this time.
+* The `isWorking` field indicates... [?]
 
 
 **Response:**


### PR DESCRIPTION
Some Binance responses return a boolean `isWorking` field. This field is completely undocumented, and nothing shows up on Google either. This PR is just a placeholder, as there's no issue tracker I can ask this in.

The reason I ask is because I noticed some strange API behaviour — which is either a bug, or might be explained by `isWorking` (if I had any idea what it means)...

* I made a `DELETE` request for an existing order. The order's status was `NEW`.
* Binance returned a response for the order with a status of `CANCELED`.
* A few moments later, I made a `GET` request for the same order. The response came back with the status `NEW` again — despite having just been reported as `CANCELED` in the previous request.
* The only difference I could tell was that the second response had the `isWorking` field, which was set to `false`. `isWorking` was not returned in the first response.