### PR TITLE
Chinese doc enum

### DIFF
--- a/rest-api.md
+++ b/rest-api.md
@@ -2040,7 +2040,7 @@ The `ICEBERG_PARTS` filter defines the maximum parts an iceberg order can have. 
 }
 ```
 
-### MARKET_LOT_SIZE
+### MARKET\_LOT\_SIZE
 The `MARKET_LOT_SIZE` filter defines the `quantity` (aka "lots" in auction terms) rules for `MARKET` orders on a symbol. There are 3 parts:
 
 * `minQty` defines the minimum `quantity` allowed.
@@ -2063,7 +2063,7 @@ In order to pass the `market lot size`, the following must be true for `quantity
 }
 ```
 
-### MAX_NUM_ORDERS
+### MAX\_NUM\_ORDERS
 The `MAX_NUM_ORDERS` filter defines the maximum number of orders an account is allowed to have open on a symbol.
 Note that both "algo" orders and normal orders are counted for this filter.
 
@@ -2075,7 +2075,7 @@ Note that both "algo" orders and normal orders are counted for this filter.
 }
 ```
 
-### MAX_NUM_ALGO_ORDERS
+### MAX\_NUM\_ALGO\_ORDERS
 The `MAX_NUM_ALGO_ORDERS` filter defines the maximum number of "algo" orders an account is allowed to have open on a symbol.
 "Algo" orders are `STOP_LOSS`, `STOP_LOSS_LIMIT`, `TAKE_PROFIT`, and `TAKE_PROFIT_LIMIT` orders.
 
@@ -2087,7 +2087,7 @@ The `MAX_NUM_ALGO_ORDERS` filter defines the maximum number of "algo" orders an 
 }
 ```
 
-### MAX_NUM_ICEBERG_ORDERS
+### MAX\_NUM\_ICEBERG\_ORDERS
 The `MAX_NUM_ICEBERG_ORDERS` filter defines the maximum number of `ICEBERG` orders an account is allowed to have open on a symbol.
 An `ICEBERG` order is any order where the `icebergQty` is > 0.
 
@@ -2118,7 +2118,7 @@ The `MAX_POSITION` filter defines the allowed maximum position an account can ha
 
 
 ## Exchange Filters
-### EXCHANGE_MAX_NUM_ORDERS
+### EXCHANGE\_MAX\_NUM\_ORDERS
 The `MAX_NUM_ORDERS` filter defines the maximum number of orders an account is allowed to have open on the exchange.
 Note that both "algo" orders and normal orders are counted for this filter.
 
@@ -2130,7 +2130,7 @@ Note that both "algo" orders and normal orders are counted for this filter.
 }
 ```
 
-### EXCHANGE_MAX_NUM_ALGO_ORDERS
+### EXCHANGE\_MAX\_NUM\_ALGO\_ORDERS
 The `MAX_ALGO_ORDERS` filter defines the maximum number of "algo" orders an account is allowed to have open on the exchange.
 "Algo" orders are `STOP_LOSS`, `STOP_LOSS_LIMIT`, `TAKE_PROFIT`, and `TAKE_PROFIT_LIMIT` orders.
 

--- a/rest-api.md
+++ b/rest-api.md
@@ -2040,7 +2040,7 @@ The `ICEBERG_PARTS` filter defines the maximum parts an iceberg order can have. 
 }
 ```
 
-### MARKET\_LOT\_SIZE
+### MARKET_LOT_SIZE
 The `MARKET_LOT_SIZE` filter defines the `quantity` (aka "lots" in auction terms) rules for `MARKET` orders on a symbol. There are 3 parts:
 
 * `minQty` defines the minimum `quantity` allowed.
@@ -2063,7 +2063,7 @@ In order to pass the `market lot size`, the following must be true for `quantity
 }
 ```
 
-### MAX\_NUM\_ORDERS
+### MAX_NUM_ORDERS
 The `MAX_NUM_ORDERS` filter defines the maximum number of orders an account is allowed to have open on a symbol.
 Note that both "algo" orders and normal orders are counted for this filter.
 
@@ -2075,7 +2075,7 @@ Note that both "algo" orders and normal orders are counted for this filter.
 }
 ```
 
-### MAX\_NUM\_ALGO\_ORDERS
+### MAX_NUM_ALGO_ORDERS
 The `MAX_NUM_ALGO_ORDERS` filter defines the maximum number of "algo" orders an account is allowed to have open on a symbol.
 "Algo" orders are `STOP_LOSS`, `STOP_LOSS_LIMIT`, `TAKE_PROFIT`, and `TAKE_PROFIT_LIMIT` orders.
 
@@ -2087,7 +2087,7 @@ The `MAX_NUM_ALGO_ORDERS` filter defines the maximum number of "algo" orders an 
 }
 ```
 
-### MAX\_NUM\_ICEBERG\_ORDERS
+### MAX_NUM_ICEBERG_ORDERS
 The `MAX_NUM_ICEBERG_ORDERS` filter defines the maximum number of `ICEBERG` orders an account is allowed to have open on a symbol.
 An `ICEBERG` order is any order where the `icebergQty` is > 0.
 
@@ -2118,7 +2118,7 @@ The `MAX_POSITION` filter defines the allowed maximum position an account can ha
 
 
 ## Exchange Filters
-### EXCHANGE\_MAX\_NUM\_ORDERS
+### EXCHANGE_MAX_NUM_ORDERS
 The `MAX_NUM_ORDERS` filter defines the maximum number of orders an account is allowed to have open on the exchange.
 Note that both "algo" orders and normal orders are counted for this filter.
 
@@ -2130,7 +2130,7 @@ Note that both "algo" orders and normal orders are counted for this filter.
 }
 ```
 
-### EXCHANGE\_MAX\_NUM\_ALGO\_ORDERS
+### EXCHANGE_MAX_NUM_ALGO_ORDERS
 The `MAX_ALGO_ORDERS` filter defines the maximum number of "algo" orders an account is allowed to have open on the exchange.
 "Algo" orders are `STOP_LOSS`, `STOP_LOSS_LIMIT`, `TAKE_PROFIT`, and `TAKE_PROFIT_LIMIT` orders.
 

--- a/rest-api_CN.md
+++ b/rest-api_CN.md
@@ -170,7 +170,7 @@ There is no & between "GTC" and "quantity=1".
 
 
 ## 枚举定义
-**交易对状态:**
+**交易对状态 (status):**
 
 * PRE_TRADING 盘前交易
 * TRADING 正常交易中
@@ -184,7 +184,7 @@ There is no & between "GTC" and "quantity=1".
 
 * SPOT 现货
 
-**订单状态:**
+**订单状态 (status):**
 
 * NEW 新建订单
 * PARTIALLY_FILLED  部分成交
@@ -194,34 +194,34 @@ There is no & between "GTC" and "quantity=1".
 * REJECTED 订单被拒绝
 * EXPIRED 订单过期(根据timeInForce参数规则)
 
-**订单种类:**
+**订单种类 (orderTypes, type):**
 
 * LIMIT 限价单
 * MARKET  市价单
 * STOP_LOSS 止损单
-* STOP_LOSS_LIMIT 限价止损单
+* STOP\_LOSS\_LIMIT 限价止损单
 * TAKE_PROFIT 止盈单
-* TAKE_PROFIT_LIMIT 限价止盈单
+* TAKE\_PROFIT\_LIMIT 限价止盈单
 * LIMIT_MAKER 限价做市单
 
-**订单返回类型:**
+**订单返回类型 (newOrderRespType):**
 
 * ACK
 * RESULT
 * FULL
 
-**订单方向:**
+**订单方向 (side):**
 
-* 买入
-* 卖出
+* BUY - 买入
+* SELL - 卖出
 
-**Time in force:**
+**Time in force (timeInForce):**
 
 * GTC - Good Till Cancel 成交为止
 * IOC - Immediate or Cancel 无法立即成交(吃单)的部分就撤销
 * FOK - Fill or Kill 无法全部立即成交就撤销
 
-**K线间隔:**
+**K线间隔 (interval):**
 
 m -> 分钟; h -> 小时; d -> 天; w -> 周; M -> 月
 
@@ -241,13 +241,13 @@ m -> 分钟; h -> 小时; d -> 天; w -> 周; M -> 月
 * 1w
 * 1M
 
-**限制种类 (rateLimitType)**
+**限制种类 (rateLimitType):**
 
-* REQUESTS_WEIGHT  单位时间请求权重之和上限
-* ORDERS    单位时间下单(撤单)次数上限
-* RAW_REQUESTS  单位时间请求次数上限
+* REQUESTS_WEIGHT - 单位时间请求权重之和上限
+* ORDERS - 单位时间下单(撤单)次数上限
+* RAW_REQUESTS - 单位时间请求次数上限
 
-**限制间隔**
+**限制间隔 (interval):**
 
 * SECOND
 * MINUTE

--- a/rest-api_CN.md
+++ b/rest-api_CN.md
@@ -552,7 +552,7 @@ GET /api/v3/klines
 Name | Type | Mandatory | Description
 ------------ | ------------ | ------------ | ------------
 symbol | STRING | YES |
-interval | ENUM | YES |
+interval | ENUM | YES | 详见枚举定义：K线间隔
 startTime | LONG | NO |
 endTime | LONG | NO |
 limit | INT | NO | Default 500; max 1000.
@@ -785,10 +785,11 @@ POST /api/v3/order  (HMAC SHA256)
 Name | Type | Mandatory | Description
 ------------ | ------------ | ------------ | ------------
 symbol | STRING | YES |
-side | ENUM | YES |
-type | ENUM | YES |
-timeInForce | ENUM | NO |
-quantity | DECIMAL | YES |
+side | ENUM | YES | 详见枚举定义：订单方向
+type | ENUM | YES | 详见枚举定义：订单种类
+timeInForce | ENUM | NO | 详见枚举定义：Time in force
+quantity | DECIMAL | NO |
+quoteOrderQty | DECIMAL | NO |
 price | DECIMAL | NO |
 newClientOrderId | STRING | NO | 用户自定义的orderid，如空缺系统会自动赋值
 stopPrice | DECIMAL | NO | 仅 `STOP_LOSS`, `STOP_LOSS_LIMIT`, `TAKE_PROFIT`, `TAKE_PROFIT_LIMIT` 需要此参数
@@ -1372,10 +1373,10 @@ lots是拍卖术语，这个过滤器对订单中的`quantity`也就是数量参
   }
 ```
 
-### MARKET_LOT_SIZE 市价订单尺寸
+### MARKET\_LOT\_SIZE 市价订单尺寸
 参考LOT_SIZE，区别仅在于对市价单还是限价单生效
 
-### MAX_NUM_ORDERS 最多订单数
+### MAX\_NUM\_ORDERS 最多订单数
 定义了某个交易对最多允许的挂单数量（不包括已关闭的订单）
 普通订单与条件订单均计算在内
 
@@ -1387,7 +1388,7 @@ lots是拍卖术语，这个过滤器对订单中的`quantity`也就是数量参
   }
 ```
 
-### MAX_NUM_ALGO_ORDERS 最多条件单数
+### MAX\_NUM\_ALGO\_ORDERS 最多条件单数
 定义了某个交易对最多允许的条件单数量（不包括已关闭的订单）
 
 **/exchangeInfo 响应中的格式:**
@@ -1398,7 +1399,7 @@ lots是拍卖术语，这个过滤器对订单中的`quantity`也就是数量参
   }
 ```
 
-### MAX_NUM_ICEBERG_ORDERS 最多冰山单数
+### MAX\_NUM\_ICEBERG\_ORDERS 最多冰山单数
 定义了某个交易对最多允许的冰山订单数
 `icebergQty` > 0.
 
@@ -1428,7 +1429,7 @@ lots是拍卖术语，这个过滤器对订单中的`quantity`也就是数量参
 ```
 
 ## 交易所级别过滤器
-### EXCHANGE_MAX_NUM_ORDERS 最多订单数
+### EXCHANGE\_MAX\_NUM\_ORDERS 最多订单数
 
 **/exchangeInfo 响应中的格式:**
 ```javascript
@@ -1438,7 +1439,7 @@ lots是拍卖术语，这个过滤器对订单中的`quantity`也就是数量参
   }
 ```
 
-### EXCHANGE_MAX_NUM_ALGO_ORDERS 最多条件单数
+### EXCHANGE\_MAX\_NUM\_ALGO\_ORDERS 最多条件单数
 
 **/exchangeInfo 响应中的格式:**
 ```javascript

--- a/rest-api_CN.md
+++ b/rest-api_CN.md
@@ -199,9 +199,9 @@ There is no & between "GTC" and "quantity=1".
 * LIMIT 限价单
 * MARKET  市价单
 * STOP_LOSS 止损单
-* STOP\_LOSS\_LIMIT 限价止损单
+* STOP_LOSS_LIMIT 限价止损单
 * TAKE_PROFIT 止盈单
-* TAKE\_PROFIT\_LIMIT 限价止盈单
+* TAKE_PROFIT_LIMIT 限价止盈单
 * LIMIT_MAKER 限价做市单
 
 **订单返回类型 (newOrderRespType):**
@@ -1373,10 +1373,10 @@ lots是拍卖术语，这个过滤器对订单中的`quantity`也就是数量参
   }
 ```
 
-### MARKET\_LOT\_SIZE 市价订单尺寸
+### MARKET_LOT_SIZE 市价订单尺寸
 参考LOT_SIZE，区别仅在于对市价单还是限价单生效
 
-### MAX\_NUM\_ORDERS 最多订单数
+### MAX_NUM_ORDERS 最多订单数
 定义了某个交易对最多允许的挂单数量（不包括已关闭的订单）
 普通订单与条件订单均计算在内
 
@@ -1388,7 +1388,7 @@ lots是拍卖术语，这个过滤器对订单中的`quantity`也就是数量参
   }
 ```
 
-### MAX\_NUM\_ALGO\_ORDERS 最多条件单数
+### MAX_NUM_ALGO_ORDERS 最多条件单数
 定义了某个交易对最多允许的条件单数量（不包括已关闭的订单）
 
 **/exchangeInfo 响应中的格式:**
@@ -1399,7 +1399,7 @@ lots是拍卖术语，这个过滤器对订单中的`quantity`也就是数量参
   }
 ```
 
-### MAX\_NUM\_ICEBERG\_ORDERS 最多冰山单数
+### MAX_NUM_ICEBERG_ORDERS 最多冰山单数
 定义了某个交易对最多允许的冰山订单数
 `icebergQty` > 0.
 
@@ -1429,7 +1429,7 @@ lots是拍卖术语，这个过滤器对订单中的`quantity`也就是数量参
 ```
 
 ## 交易所级别过滤器
-### EXCHANGE\_MAX\_NUM\_ORDERS 最多订单数
+### EXCHANGE_MAX_NUM_ORDERS 最多订单数
 
 **/exchangeInfo 响应中的格式:**
 ```javascript
@@ -1439,7 +1439,7 @@ lots是拍卖术语，这个过滤器对订单中的`quantity`也就是数量参
   }
 ```
 
-### EXCHANGE\_MAX\_NUM\_ALGO\_ORDERS 最多条件单数
+### EXCHANGE_MAX_NUM_ALGO_ORDERS 最多条件单数
 
 **/exchangeInfo 响应中的格式:**
 ```javascript


### PR DESCRIPTION
1. Add escape character before `_` to prevent from some editor misinterpret it as _italic_.
2. Add English enum name beside Chinese enum name for reference.
3. Add Chinese description regarding the enum parameters.
4. Correct order API parameter list.