### PR TITLE
Issue - cannot request recent trades for multiple symbols

### DIFF
--- a/issue.md
+++ b/issue.md
@@ -1,0 +1,1 @@
+Recreating https://github.com/binance-exchange/binance-official-api-docs/pull/6


### PR DESCRIPTION
Sorry for creating a new file, but I can't see where to file an issue about the API. It would be nice to enable the Issues option for this repo.

Sorry for asking for this again [after almost 4 years](https://github.com/binance-exchange/binance-official-api-docs/pull/6), but it seems the old repo was abandoned.

My issue is: how can I get a list of all my trades `since` a timestamp, or from a `fromId`? The [myTrades](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#account-trade-list-user_data) endpoint requires a symbol, but I want *all* my recent trades, for all symbols I've traded. This is standard with other exchanges, either directly like [Kraken](https://www.kraken.com/help/api#get-trades-history), or with a special symbol parameter, e.g. ["all" for Poloniex/returnTradeHistory](https://poloniex.com/support/api/).

The only way I've found to get all my recent trades, assuming I don't want to risk forgetting a pair, was to [iterate through all the symbols](https://github.com/ccxt/ccxt/pull/1079/files#diff-ff11f07237c719dc4ab44d74374f8a8fR58) which,
* is silly and wasteful, because most users have only traded a small subset of all the pairs. **There are over 1700 pairs** at the moment.
* is slow, because it takes more than 10 minutes.

Is there a smarter way to get all my trades from Binance?