### PR TITLE
Fix a typo

### DIFF
--- a/rest-api.md
+++ b/rest-api.md
@@ -978,7 +978,7 @@ symbol | STRING | YES |
 side | ENUM | YES |
 type | ENUM | YES |
 timeInForce | ENUM | NO |
-quantity | DECIMAL | NO |
+quantity | DECIMAL | YES |
 quoteOrderQty|DECIMAL|NO|
 price | DECIMAL | NO |
 newClientOrderId | STRING | NO | A unique id among open orders. Automatically generated if not sent.<br> Orders with the same `newClientOrderID` can be accepted only when the previous one is filled, otherwise the order will be rejected.


### PR DESCRIPTION
Quantity is mandatory, otherwise this error is returned:
```
{
  code: -1102,
  msg: "Mandatory parameter 'quantity' was not sent, was empty/null, or malformed."
}
```