### PR TITLE
Missing new order trade id documentation

### DIFF
--- a/rest-api.md
+++ b/rest-api.md
@@ -1071,24 +1071,28 @@ Matching Engine
       "price": "3999.00000000",
       "qty": "5.00000000",
       "commission": "19.99500000",
+      "commissionAsset": "USDT",
       "tradeId": 57
     },
     {
       "price": "3998.00000000",
       "qty": "2.00000000",
       "commission": "7.99600000",
+      "commissionAsset": "USDT",
       "tradeId": 58
     },
     {
       "price": "3997.00000000",
       "qty": "1.00000000",
       "commission": "3.99700000",
+      "commissionAsset": "USDT",
       "tradeId": 59
     },
     {
       "price": "3995.00000000",
       "qty": "1.00000000",
       "commission": "3.99500000",
+      "commissionAsset": "USDT",
       "tradeId": 60
     }
   ]

--- a/rest-api.md
+++ b/rest-api.md
@@ -1064,31 +1064,32 @@ Matching Engine
       "price": "4000.00000000",
       "qty": "1.00000000",
       "commission": "4.00000000",
-      "commissionAsset": "USDT"
+      "commissionAsset": "USDT",
+      "tradeId": 56
     },
     {
       "price": "3999.00000000",
       "qty": "5.00000000",
       "commission": "19.99500000",
-      "commissionAsset": "USDT"
+      "tradeId": 57
     },
     {
       "price": "3998.00000000",
       "qty": "2.00000000",
       "commission": "7.99600000",
-      "commissionAsset": "USDT"
+      "tradeId": 58
     },
     {
       "price": "3997.00000000",
       "qty": "1.00000000",
       "commission": "3.99700000",
-      "commissionAsset": "USDT"
+      "tradeId": 59
     },
     {
       "price": "3995.00000000",
       "qty": "1.00000000",
       "commission": "3.99500000",
-      "commissionAsset": "USDT"
+      "tradeId": 60
     }
   ]
 }

--- a/rest-api_CN.md
+++ b/rest-api_CN.md
@@ -895,31 +895,36 @@ Type | 强制要求的参数
       "price": "4000.00000000",
       "qty": "1.00000000",
       "commission": "4.00000000",
-      "commissionAsset": "USDT"
+      "commissionAsset": "USDT",
+      "tradeId": 56
     },
     {
       "price": "3999.00000000",
       "qty": "5.00000000",
       "commission": "19.99500000",
-      "commissionAsset": "USDT"
+      "commissionAsset": "USDT",
+      "tradeId": 57
     },
     {
       "price": "3998.00000000",
       "qty": "2.00000000",
       "commission": "7.99600000",
-      "commissionAsset": "USDT"
+      "commissionAsset": "USDT",
+      "tradeId": 58
     },
     {
       "price": "3997.00000000",
       "qty": "1.00000000",
       "commission": "3.99700000",
-      "commissionAsset": "USDT"
+      "commissionAsset": "USDT",
+      "tradeId": 59
     },
     {
       "price": "3995.00000000",
       "qty": "1.00000000",
       "commission": "3.99500000",
-      "commissionAsset": "USDT"
+      "commissionAsset": "USDT",
+      "tradeId": 60
     }
   ]
 }


### PR DESCRIPTION
Updated the New Order endpoint (`/api/v3/order`) to include the `tradeId` property for trades returned.