### PR TITLE
Updated Market Data Only URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-# CHANGELOG for Binance's API (2023-03-13)
+# CHANGELOG for Binance's API (2023-05-24)
+
+## 2023-05-24
+
+* **The previous market data URLs have been deprecated. Please update your code immediately to prevent interruption of our services.**
+    * API Market data from `data.binance.com` can now be accessed from `data-api.binance.vision`.
+    * Websocket Market Data from `data-stream.binance.com` can now be accessed from `data-stream.binance.vision`.
+
+---
 
 ## 2023-03-13
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -2,7 +2,7 @@
 
 ## 2023-05-24
 
-* 以前的市场数据 URL 已不建议使用。请立即更新您的代码，以防止来自我们的服务被中断。
+* **以前的市场数据 URL 已不建议使用。请立即更新您的代码，以防止来自我们的服务被中断**
     * 来自 `data.binance.com` 的 API 市场数据现在可以从 `data-api.binance.vision` 访问。
     * 来自 `data-stream.binance.com` 的 Websocket 市场数据现在可以从 `data-stream.binance.vision` 访问。
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,4 +1,12 @@
-# 更新日志 (2023-03-13)
+# 更新日志 (2023-05-24)
+
+## 2023-05-24
+
+* 以前的市场数据 URL 已不建议使用。请立即更新您的代码，以防止来自我们的服务被中断。
+    * 来自 `data.binance.com` 的 API 市场数据现在可以从 `data-api.binance.vision` 访问。
+    * 来自 `data-stream.binance.com` 的 Websocket 市场数据现在可以从 `data-stream.binance.vision` 访问。
+
+---
 
 ## 2023-03-13
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Name | Description
 [spot_glossary.md](./faqs/spot_glossary.md) | Definition of terms used in the API
 [trailing-stop-faq.md](./faqs/trailing-stop-faq.md)   | Detailed Information on the behavior of Trailing Stops on the API
 [stp-faq.md](./faqs/stp_faq.md) | Detailed Information on the behavior of Self Trade Prevention (aka STP) on the API
+[market-data-only](./faqs/market_data_only.md) | Information on our market data only API and websocket streams.
 
 
 # Useful Resources

--- a/README_CN.md
+++ b/README_CN.md
@@ -30,6 +30,7 @@
 [spot_glossary_cn.md](./faqs/spot_glossary_cn.md) | 现货交易API术语表
 [trailing-stop-faq-cn.md](./faqs/trailing-stop-faq-cn.md)   | 追踪止盈止损订单(Trailing Stop)详细信息和常见问题
 [stp-faq_cn.md](./faqs/stp_faq_cn.md) | 关于 Self Trade Prevention (STP) 的详细信息
+[market-data-only_cn.md](./faqs/market_data_only_cn.md) | 仅提供市场数据的 API 和 Websocket Streams
 
 # 相关信息
 

--- a/faqs/market_data_only.md
+++ b/faqs/market_data_only.md
@@ -1,0 +1,42 @@
+# Market Data Only URLs
+
+These URLs do not require any authentication (i.e. The API key is not necessary) and serve only public market data.
+
+## RESTful API
+
+On the RESTful API, these are the endpoints you can request on `data-api.binance.vision`: 
+
+* [GET /api/v3/aggTrades](../rest-api.md#compressedaggregate-trades-list)
+* [GET /api/v3/avgPrice](../rest-api.md#current-average-price)
+* [GET /api/v3/depth](../rest-api.md#order-book)
+* [GET /api/v3/exchangeInfo](../rest-api.md#exchange-information)
+* [GET /api/v3/klines](../rest-api.md#klines)
+* [GET /api/v3/ping](../rest-api.md#ping)
+* [GET /api/v3/ticker](../rest-api.md#rolling-window-price-change-statistics)
+* [GET /api/v3/ticker/24hr](../rest-api.md#24hr-ticker-price-change-statistics)
+* [GET /api/v3/ticker/bookTicker](../rest-api.md#symbol-order-book-ticker)
+* [GET /api/v3/ticker/price](../rest-api.md#symbol-price-ticker)
+* [GET /api/v3/time](../rest-api.md#time)
+* [GET /api/v3/trades](../rest-api.md#recent-trades-list)
+* [GET /api/v3/uiKlines](../rest-api.md#uiKlines)
+
+Sample request:
+
+```
+curl -sX GET "https://data-api.binance.vision/api/v3/exchangeInfo?symbol=BTCUSDT" 
+```
+
+## Websocket Streams
+
+Public market data can also be retrieved through the websocket market data using the URL `data-stream.binance.vision`.
+The streams available through this domain are the same that can be found in the [Websocket Market Streams](../web-socket-streams.md) documentation.
+
+Note that User Data Streams **cannot** be accessed through this URL.
+
+Sample request:
+
+```
+wss://data-stream.binance.vision:443/ws/btcusdt@kline_1m
+```
+
+

--- a/faqs/market_data_only_cn.md
+++ b/faqs/market_data_only_cn.md
@@ -1,0 +1,40 @@
+# 仅提供市场数据的URL
+
+这些 URL 不需要任何身份验证（即不需要 API Key）并且仅提供公开市场数据。
+
+## RESTful API
+
+在 RESTful API 上，您可以在 `data-api.binance.vision` 上访问以下接口：
+
+* [GET /api/v3/aggTrades](../rest-api_CN.md#近期成交归集)
+* [GET /api/v3/avgPrice](../rest-api_CN.md#当前平均价格)
+* [GET /api/v3/depth](../rest-api_CN.md#深度信息)
+* [GET /api/v3/exchangeInfo](../rest-api_CN.md#交易规范信息)
+* [GET /api/v3/klines](../rest-api_CN.md#k线数据)
+* [GET /api/v3/ping](../rest-api_CN.md#测试服务器连通性-ping)
+* [GET /api/v3/ticker](../rest-api_CN.md#滚动窗口价格变动统计)
+* [GET /api/v3/ticker/24hr](../rest-api_CN.md#24hr价格变动情况)
+* [GET /api/v3/ticker/bookTicker](../rest-api_CN.md#最优挂单接口)
+* [GET /api/v3/ticker/price](../rest-api_CN.md#最新价格接口)
+* [GET /api/v3/time](../rest-api_CN.md#获取服务器时间)
+* [GET /api/v3/trades](../rest-api_CN.md#近期成交)
+* [GET /api/v3/uiKlines](../rest-api_CN.md#uik线数据)
+
+请求示例:
+
+```
+curl -sX GET "https://data-api.binance.vision/api/v3/exchangeInfo?symbol=BTCUSDT" 
+```
+
+## Websocket Streams
+
+也可以通过 Websocket 市场数据的 URL `data-stream.binance.vision` 提取公共市场数据。
+此域名所提供的 stream 与 [Websocket Market Streams_CN](../web-socket-streams_CN.md) 文档中的相同。
+请注意账户信息推送**无法**从此 URL 获得。
+
+请求示例:
+
+```
+wss://data-stream.binance.vision:443/ws/btcusdt@kline_1m
+```
+

--- a/rest-api.md
+++ b/rest-api.md
@@ -66,7 +66,7 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-# Public Rest API for Binance (2023-03-13)
+# Public Rest API for Binance (2023-05-24)
 
 ## General API Information
 * The following base endpoints are available:
@@ -79,20 +79,7 @@
 * All endpoints return either a JSON object or array.
 * Data is returned in **ascending** order. Oldest first, newest last.
 * All time and timestamp related fields are in **milliseconds**.
-* The base endpoint **https://data.binance.com** can be used to access the following API endpoints that have `NONE` as security type:
-  * GET /api/v3/aggTrades
-  * GET /api/v3/avgPrice
-  * GET /api/v3/depth
-  * GET /api/v3/exchangeInfo
-  * GET /api/v3/klines
-  * GET /api/v3/ping
-  * GET /api/v3/ticker
-  * GET /api/v3/ticker/24hr
-  * GET /api/v3/ticker/bookTicker
-  * GET /api/v3/ticker/price
-  * GET /api/v3/time
-  * GET /api/v3/trades
-  * GET /api/v3/uiKlines
+* For APIs that only send public market data, you use the base endpoint **https://data-api.binance.vision**. Please refer to [Market Data Only](.faqs/market_data_only.md) page.
 
 ## HTTP Return Codes
 

--- a/rest-api_CN.md
+++ b/rest-api_CN.md
@@ -1,4 +1,4 @@
-# REST行情与交易接口 (2023-03-13)
+# REST行情与交易接口 (2023-05-24)
 
 ## API 基本信息
 * 本篇列出接口的 base URL 有:
@@ -11,20 +11,7 @@
 * 所有接口的响应都是 JSON 格式。
 * 响应中如有数组，数组元素以时间**升序**排列，越早的数据越提前。
 * 所有时间、时间戳均为UNIX时间，单位为**毫秒**。
-* URL **https://data.binance.com** 可以用来访问下面鉴权类型为 `NONE` 的接口:
-  * GET /api/v3/aggTrades
-  * GET /api/v3/avgPrice
-  * GET /api/v3/depth
-  * GET /api/v3/exchangeInfo
-  * GET /api/v3/klines
-  * GET /api/v3/ping
-  * GET /api/v3/ticker
-  * GET /api/v3/ticker/24hr
-  * GET /api/v3/ticker/bookTicker
-  * GET /api/v3/ticker/price
-  * GET /api/v3/time
-  * GET /api/v3/trades
-  * GET /api/v3/uiKlines
+* 对于仅发送公开市场数据的 API，您可以使用接口的 base URL https://data-api.binance.vision 。请参考 [Market Data Only_CN](./faqs/market_data_only_cn.md) 页面。
 
 ## HTTP 返回代码
 

--- a/web-socket-streams.md
+++ b/web-socket-streams.md
@@ -28,7 +28,7 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-# Web Socket Streams for Binance (2023-02-17)
+# Web Socket Streams for Binance (2023-05-24)
 
 # General WSS information
 * The base endpoint is: **wss://stream.binance.com:9443** or **wss://stream.binance.com:443**
@@ -39,7 +39,7 @@
 * All symbols for streams are **lowercase**
 * A single connection to **stream.binance.com** is only valid for 24 hours; expect to be disconnected at the 24 hour mark
 * The websocket server will send a `ping frame` every 3 minutes. If the websocket server does not receive a `pong frame` back from the connection within a 10 minute period, the connection will be disconnected. Unsolicited `pong frames` are allowed.
-* The base endpoint **wss://data-stream.binance.com** can be subscribed to receive market data messages. Users data stream is **NOT** available from this URL.
+* The base endpoint **wss://data-stream.binance.vision** can be subscribed to receive **only** market data messages. <br> User data stream is **NOT** available from this URL.
 
 ## Websocket Limits
 * WebSocket connections have a limit of 5 incoming messages per second. A message is considered:

--- a/web-socket-streams_CN.md
+++ b/web-socket-streams_CN.md
@@ -1,5 +1,5 @@
 
-# Web Socket 行情接口(2023-02-17)
+# Web Socket 行情接口(2023-05-24)
 # 基本信息
 * 本篇所列出的所有wss接口的baseurl为: **wss://stream.binance.com:9443** 或者 **wss://stream.binance.com:443**
 * 所有stream均可以直接访问，或者作为组合streams的一部分。
@@ -9,7 +9,7 @@
 * stream名称中所有交易对均为**小写**
 * 每个到**stream.binance.com**的链接有效期不超过24小时，请妥善处理断线重连。
 * 每3分钟，服务端会发送ping帧，客户端应当在10分钟内回复pong帧，否则服务端会主动断开链接。允许客户端发送不成对的pong帧(即客户端可以以高于10分钟每次的频率发送pong帧保持链接)。
-* **wss://data-stream.binance.com** 可以用来订阅市场信息的数据流。 用户信息无法从此URL获得。
+* **wss://data-stream.binance.vision** 可以用来订阅仅有市场信息的数据流。账户信息**无法**从此URL获得。
 
 ## WebSocket 连接限制
 


### PR DESCRIPTION
The previous URLs  to access just the public market data from the restful API and the websocket streams have been deprecated. (I.e. They are currently supported but will be removed in the near future.)

Please update your code to prevent any service interruptions from our side.
