### PR TITLE
Updating documentation re: HMAC keys

### DIFF
--- a/rest-api.md
+++ b/rest-api.md
@@ -1603,7 +1603,7 @@ When using `symbols`:
 
 ### New order  (TRADE)
 ```
-POST /api/v3/order  (HMAC SHA256)
+POST /api/v3/order 
 ```
 Send in a new order.
 
@@ -1771,7 +1771,7 @@ Field          |Description                                                     
 
 ### Test new order (TRADE)
 ```
-POST /api/v3/order/test (HMAC SHA256)
+POST /api/v3/order/test
 ```
 Test new order creation and signature/recvWindow long.
 Creates and validates a new order but does not send it into the matching engine.
@@ -1793,7 +1793,7 @@ Memory
 
 ### Query order (USER_DATA)
 ```
-GET /api/v3/order (HMAC SHA256)
+GET /api/v3/order 
 ```
 Check an order's status.
 
@@ -1847,7 +1847,7 @@ Memory => Database
 
 ### Cancel order (TRADE)
 ```
-DELETE /api/v3/order  (HMAC SHA256)
+DELETE /api/v3/order 
 ```
 Cancel an active order.
 
@@ -1914,7 +1914,7 @@ Matching Engine
 
 ### Cancel All Open Orders on a Symbol (TRADE)
 ```
-DELETE /api/v3/openOrders (HMAC SHA256)
+DELETE /api/v3/openOrders 
 ```
 Cancels all active orders on a symbol.
 This includes OCO orders.
@@ -2223,7 +2223,7 @@ Matching Engine
 
 ### Current open orders (USER_DATA)
 ```
-GET /api/v3/openOrders  (HMAC SHA256)
+GET /api/v3/openOrders
 ```
 Get all open orders on a symbol. **Careful** when accessing this with no symbol.
 
@@ -2275,7 +2275,7 @@ Memory => Database
 
 ### All orders (USER_DATA)
 ```
-GET /api/v3/allOrders (HMAC SHA256)
+GET /api/v3/allOrders
 ```
 Get all account orders; active, canceled, or filled.
 
@@ -2335,7 +2335,7 @@ timestamp | LONG | YES |
 ### New OCO (TRADE)
 
 ```
-POST /api/v3/order/oco (HMAC SHA256)
+POST /api/v3/order/oco 
 ```
 
 **Weight**: 1
@@ -2449,7 +2449,7 @@ Matching Engine
 ### Cancel OCO (TRADE)
 
 ```
-DELETE /api/v3/orderList (HMAC SHA256)
+DELETE /api/v3/orderList 
 ```
 
 **Weight**: 1
@@ -2541,7 +2541,7 @@ Matching Engine
 ### Query OCO (USER_DATA)
 
 ```
-GET /api/v3/orderList (HMAC SHA256)
+GET /api/v3/orderList 
 ```
 
 **Weight**: 2
@@ -2590,7 +2590,7 @@ Database
 ### Query all OCO (USER_DATA)
 
 ```
-GET /api/v3/allOrderList (HMAC SHA256)
+GET /api/v3/allOrderList
 ```
 
 **Weight**: 10
@@ -2663,7 +2663,7 @@ Database
 ### Query Open OCO (USER_DATA)
 
 ```
-GET /api/v3/openOrderList (HMAC SHA256)
+GET /api/v3/openOrderList 
 ```
 
 Weight: 3
@@ -2803,7 +2803,7 @@ Memory
 
 ### Account information (USER_DATA)
 ```
-GET /api/v3/account (HMAC SHA256)
+GET /api/v3/account 
 ```
 Get current account information.
 
@@ -2862,7 +2862,7 @@ Memory => Database
 
 ### Account trade list (USER_DATA)
 ```
-GET /api/v3/myTrades  (HMAC SHA256)
+GET /api/v3/myTrades 
 ```
 Get trades for a specific account and symbol.
 

--- a/rest-api_CN.md
+++ b/rest-api_CN.md
@@ -1523,7 +1523,7 @@ GET /api/v3/ticker
 ## 账户接口
 ### 下单  (TRADE)
 ```
-POST /api/v3/order  (HMAC SHA256)
+POST /api/v3/order 
 ```
 
 **权重:**
@@ -1690,7 +1690,7 @@ Type | 强制要求的参数 | 其他信息
 ### 测试下单接口 (TRADE)
 
 ```
-POST /api/v3/order/test (HMAC SHA256)
+POST /api/v3/order/test 
 ```
 
 用于测试订单请求，但不会提交到撮合引擎
@@ -1712,7 +1712,7 @@ POST /api/v3/order/test (HMAC SHA256)
 
 ### 查询订单 (USER_DATA)
 ```
-GET /api/v3/order (HMAC SHA256)
+GET /api/v3/order
 ```
 查询订单状态
 
@@ -1766,7 +1766,7 @@ timestamp | LONG | YES |
 
 ### 撤销订单 (TRADE)
 ```
-DELETE /api/v3/order  (HMAC SHA256)
+DELETE /api/v3/order 
 ```
 
 **权重:**
@@ -2137,7 +2137,7 @@ timestamp | LONG | YES |
 
 ### 查看账户当前挂单 (USER_DATA)
 ```
-GET /api/v3/openOrders  (HMAC SHA256)
+GET /api/v3/openOrders 
 ```
 请小心使用不带symbol参数的调用
 
@@ -2190,7 +2190,7 @@ timestamp | LONG | YES |
 
 ### 查询所有订单（包括历史订单） (USER_DATA)
 ```
-GET /api/v3/allOrders (HMAC SHA256)
+GET /api/v3/allOrders 
 ```
 
 **权重:**
@@ -2248,7 +2248,7 @@ timestamp | LONG | YES |
 ## 发送新 OCO 订单
 
 ```
-POST /api/v3/order/oco (HMAC SHA256)
+POST /api/v3/order/oco 
 ```
 
 **权重(UID)**: 2
@@ -2299,7 +2299,7 @@ timestamp|LONG|YES|
 ## 取消 OCO 订单(TRADE)
 
 ``
-DELETE /api/v3/orderList (HMAC SHA256)
+DELETE /api/v3/orderList 
 ``
 
 取消整个订单列表。
@@ -2390,7 +2390,7 @@ timestamp|LONG|YES|
 ## 查询 OCO (USER_DATA)
 
 ``
-GET /api/v3/orderList (HMAC SHA256)
+GET /api/v3/orderList 
 ``
 
 根据提供的可选参数检索特定的OCO。
@@ -2438,7 +2438,7 @@ timestamp|LONG|YES|
 ## 查询所有 OCO (USER_DATA)
 
 ``
-GET /api/v3/allOrderList (HMAC SHA256)
+GET /api/v3/allOrderList 
 ``
 
 根据提供的可选参数检索所有的OCO。
@@ -2511,7 +2511,7 @@ timestamp|LONG|YES|
 ## 查询 OCO 挂单 (USER_DATA)
 
 ``
-GET /api/v3/openOrderList (HMAC SHA256)
+GET /api/v3/openOrderList
 ``
 
 **权重(IP)**: 3
@@ -2652,7 +2652,7 @@ POST /api/v3/sor/order/test
 
 ### 账户信息 (USER_DATA)
 ```
-GET /api/v3/account (HMAC SHA256)
+GET /api/v3/account 
 ```
 
 **权重:**
@@ -2709,7 +2709,7 @@ timestamp | LONG | YES |
 
 ### 账户成交历史 (USER_DATA)
 ```
-GET /api/v3/myTrades  (HMAC SHA256)
+GET /api/v3/myTrades  
 ```
 获取某交易对的成交历史
 


### PR DESCRIPTION
Previously, the APIs were only supporting HMAC keys.

Now that APIs support asymmetric keys, we are updating documentation to not confuse users that they can only use HMAC keys for signed transactions.

**This is only a formatting change**, and we have not removed support for HMAC keys as of yet. We still recommend to switch out of HMAC keys as soon as possible.


