### PR TITLE
Added the changes to request weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **The following changes will be effective from 2023-08-25 at UTC 00:00.**
 * The `CONNECTIONS` rate limit for WebSocket API has been adjusted to 300 every 5 minutes.
+* The `REQUEST_WEIGHT` rate limit for REST API has been adjusted to 6,000 every minute.
 * The `RAW_REQUESTS` rate limit for REST API has been adjusted to 61,000 every 5 minutes.
 * Previously, connecting to WebSocket API used to cost 1 weight. **The cost is now 2**.
 * The weights to the following requests for both REST API and WebSocket API have been adjusted. 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -6,6 +6,7 @@
 
 **下面的变更会在UTC时间 2023-08-25 00:00 上线**
 * WebSocket API 的 `CONNECTIONS` 被调整为每5分钟300.
+* REST API 中的 `REQUEST_WEIGHT` 调整为每分钟6,000.
 * REST API 中的 `RAW_REQUESTS` 调整为每5分钟61,000.
 * 之前连接到 WebSocket API 的权重为1. **现权重调整到 2**.
 * 下表的 REST API 和 WebSocket API 请求的权重被调整:

--- a/rest-api.md
+++ b/rest-api.md
@@ -589,7 +589,7 @@ s-> seconds; m -> minutes; h -> hours; d -> days; w -> weeks; M -> months
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200
+      "limit": 6000
     }
 ```
 

--- a/rest-api_CN.md
+++ b/rest-api_CN.md
@@ -485,7 +485,7 @@ s -> 秒; m -> 分钟; h -> 小时; d -> 天; w -> 周; M -> 月
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200
+      "limit": 6000
     }
 ```
 

--- a/web-socket-api.md
+++ b/web-socket-api.md
@@ -365,7 +365,7 @@ the `rateLimits` field can be omitted from responses to reduce their size.
   ```
 
   ```json
-  {"id":1,"status":200,"result":{"serverTime":1656400526260},"rateLimits":[{"rateLimitType":"REQUEST_WEIGHT","interval":"MINUTE","intervalNum":1,"limit":1200,"count":70}]}
+  {"id":1,"status":200,"result":{"serverTime":1656400526260},"rateLimits":[{"rateLimitType":"REQUEST_WEIGHT","interval":"MINUTE","intervalNum":1,"limit":6000,"count":70}]}
   ```
 
   Request and response without rate limit status:
@@ -411,7 +411,7 @@ the `rateLimits` field can be omitted from responses to reduce their size.
   * `retryAfter` field indicates the timestamp when the ban will be lifted.
 * IP bans are tracked and **scale in duration** for repeat offenders, **from 2 minutes to 3 days**.
 
-Successful response indicating that in 1 minute you have used 70 weight out of your 1200 limit:
+Successful response indicating that in 1 minute you have used 70 weight out of your 6000 limit:
 
 ```json
 {
@@ -423,7 +423,7 @@ Successful response indicating that in 1 minute you have used 70 weight out of y
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 70
     }
   ]
@@ -449,7 +449,7 @@ Failed response indicating that you are banned and the ban will last until epoch
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 2411
     }
   ]
@@ -509,7 +509,7 @@ Successful response indicating that you have placed 12 orders in 10 seconds, and
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 321
     }
   ]
@@ -989,7 +989,7 @@ Memory
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -1029,7 +1029,7 @@ Memory
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -1114,7 +1114,7 @@ Memory
         "rateLimitType": "REQUEST_WEIGHT",    // Rate limit type: REQUEST_WEIGHT, ORDERS, CONNECTIONS
         "interval": "MINUTE",                 // Rate limit interval: SECOND, MINUTE, DAY
         "intervalNum": 1,                     // Rate limit interval multiplier (i.e., "1 minute")
-        "limit": 1200                         // Rate limit per interval
+        "limit": 6000                         // Rate limit per interval
       },
       {
         "rateLimitType": "ORDERS",
@@ -1207,7 +1207,7 @@ Memory
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 10
     }
   ]
@@ -1319,7 +1319,7 @@ Memory
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -1380,7 +1380,7 @@ Memory
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -1442,7 +1442,7 @@ Database
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 5
     }
   ]
@@ -1526,7 +1526,7 @@ Database
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -1617,7 +1617,7 @@ Database
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -1690,7 +1690,7 @@ Database
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -1737,7 +1737,7 @@ Memory
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -1853,7 +1853,7 @@ Memory
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -1885,7 +1885,7 @@ Memory
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -1951,7 +1951,7 @@ If more than one symbol is requested, response returns an array:
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -2100,7 +2100,7 @@ Database
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 2
     }
   ]
@@ -2132,7 +2132,7 @@ Database
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 2
     }
   ]
@@ -2186,7 +2186,7 @@ If more than one symbol is requested, response returns an array:
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 4
     }
   ]
@@ -2271,7 +2271,7 @@ Memory
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -2303,7 +2303,8 @@ If more than one symbol is requested, response returns an array:
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000
+,
       "count": 2
     }
   ]
@@ -2393,7 +2394,7 @@ Memory
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -2427,7 +2428,7 @@ If more than one symbol is requested, response returns an array:
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 2
     }
   ]
@@ -2737,7 +2738,7 @@ Response format is selected by using the `newOrderRespType` parameter.
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -2786,7 +2787,8 @@ Response format is selected by using the `newOrderRespType` parameter.
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000
+,
       "count": 1
     }
   ]
@@ -2853,7 +2855,7 @@ Response format is selected by using the `newOrderRespType` parameter.
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -2926,7 +2928,7 @@ Memory
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -3059,7 +3061,7 @@ Memory => Database
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 2
     }
   ]
@@ -3204,7 +3206,7 @@ When an individual order is canceled:
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -3281,7 +3283,7 @@ When an OCO is canceled:
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -3662,7 +3664,7 @@ If both cancel and placement succeed, you get the following response with `"stat
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -3708,7 +3710,7 @@ and returns the following response with `"status": 400`:
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -3770,7 +3772,7 @@ and the `"data"` field detailing which operation succeeded, which failed, and wh
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -3830,7 +3832,7 @@ and the `"data"` field detailing which operation succeeded, which failed, and wh
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -3878,7 +3880,7 @@ If both operations fail, response will have `"status": 400`:
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -3972,7 +3974,8 @@ If all symbols are requested, use the `symbol` field to tell which symbol the or
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000
+,
       "count": 3
     }
   ]
@@ -4111,7 +4114,7 @@ Cancellation reports for orders and OCOs have the same format as in [`order.canc
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -4296,7 +4299,7 @@ See [`order.place`](#place-new-order-trade) for more examples.
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -4417,7 +4420,7 @@ Database
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 2
     }
   ]
@@ -4584,7 +4587,7 @@ Matching Engine
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -4661,7 +4664,7 @@ Database
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 3
     }
   ]
@@ -4763,7 +4766,7 @@ Matching Engine
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -4816,7 +4819,8 @@ Memory
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000
+,
       "count": 1
     }
   ]
@@ -4907,7 +4911,8 @@ Memory => Database
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000
+,
       "count": 10
     }
   ]
@@ -4972,7 +4977,7 @@ Memory
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 20
     }
   ]
@@ -5073,7 +5078,7 @@ Note that some fields are optional and included only for orders that set them.
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 10
     }
   ]
@@ -5164,7 +5169,7 @@ Status reports for OCOs are identical to [`orderList.status`](#query-oco-user_da
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 10
     }
   ]
@@ -5268,7 +5273,7 @@ Memory => Database
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 10
     }
   ]
@@ -5350,7 +5355,7 @@ Database
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 10
     }
   ]
@@ -5437,7 +5442,7 @@ Database
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 10
     }
   ]
@@ -5497,7 +5502,7 @@ Subscribe to the received listen key on WebSocket Stream afterwards.
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -5550,7 +5555,7 @@ Memory
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -5596,7 +5601,7 @@ Memory
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]

--- a/web-socket-api.md
+++ b/web-socket-api.md
@@ -174,7 +174,7 @@ Example of successful response:
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 321
     }
   ]
@@ -210,7 +210,7 @@ Example of failed response:
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 322
     }
   ]
@@ -313,7 +313,7 @@ A response with rate limit status may look like this:
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 70
     }
   ]

--- a/web-socket-api_CN.md
+++ b/web-socket-api_CN.md
@@ -285,7 +285,7 @@ API 有多种频率限制间隔。
   ```
 
   ```json
-  {"id":1,"status":200,"result":{"serverTime":1656400526260},"rateLimits":[{"rateLimitType":"REQUEST_WEIGHT","interval":"MINUTE","intervalNum":1,"limit":1200,"count":70}]}
+  {"id":1,"status":200,"result":{"serverTime":1656400526260},"rateLimits":[{"rateLimitType":"REQUEST_WEIGHT","interval":"MINUTE","intervalNum":1,"limit":6000,"count":70}]}
   ```
 
   没有频率限制状态的请求和响应：
@@ -341,7 +341,7 @@ API 有多种频率限制间隔。
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 70
     }
   ]
@@ -367,7 +367,7 @@ API 有多种频率限制间隔。
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 2411
     }
   ]
@@ -426,7 +426,7 @@ API 有多种频率限制间隔。
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 321
     }
   ]
@@ -884,7 +884,7 @@ NONE
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -924,7 +924,7 @@ NONE
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -1009,7 +1009,7 @@ NONE
         "rateLimitType": "REQUEST_WEIGHT",    // 速率限制类型: REQUEST_WEIGHT，ORDERS，CONNECTIONS
         "interval": "MINUTE",                 // 速率限制间隔: SECOND，MINUTE，DAY
         "intervalNum": 1,                     // 速率限制间隔乘数 (i.e.，"1 minute")
-        "limit": 1200                         // 每个间隔的速率限制
+        "limit": 6000                         // 每个间隔的速率限制
       },
       {
         "rateLimitType": "ORDERS",
@@ -1102,7 +1102,7 @@ NONE
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 10
     }
   ]
@@ -1214,7 +1214,7 @@ NONE
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -1275,7 +1275,7 @@ NONE
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -1337,7 +1337,7 @@ NONE
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 5
     }
   ]
@@ -1419,7 +1419,7 @@ NONE
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -1509,7 +1509,7 @@ months    | `1M`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -1580,7 +1580,7 @@ uiKlines 是返回修改后的k线数据，针对k线图的呈现进行了优化
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -1627,7 +1627,7 @@ uiKlines 是返回修改后的k线数据，针对k线图的呈现进行了优化
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -1741,7 +1741,7 @@ uiKlines 是返回修改后的k线数据，针对k线图的呈现进行了优化
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -1773,7 +1773,7 @@ uiKlines 是返回修改后的k线数据，针对k线图的呈现进行了优化
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -1839,7 +1839,7 @@ uiKlines 是返回修改后的k线数据，针对k线图的呈现进行了优化
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -1986,7 +1986,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 2
     }
   ]
@@ -2018,7 +2018,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 2
     }
   ]
@@ -2072,7 +2072,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 4
     }
   ]
@@ -2157,7 +2157,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -2189,7 +2189,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 2
     }
   ]
@@ -2279,7 +2279,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -2313,7 +2313,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 2
     }
   ]
@@ -2615,7 +2615,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -2664,7 +2664,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -2730,7 +2730,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -2800,7 +2800,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -2931,7 +2931,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 2
     }
   ]
@@ -3074,7 +3074,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 2
     }
   ]
@@ -3151,7 +3151,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -3529,7 +3529,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -3574,7 +3574,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -3635,7 +3635,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -3693,7 +3693,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -3741,7 +3741,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -3835,7 +3835,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 3
     }
   ]
@@ -3971,7 +3971,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -4151,7 +4151,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -4271,7 +4271,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 2
     }
   ]
@@ -4437,7 +4437,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -4514,7 +4514,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 3
     }
   ]
@@ -4616,7 +4616,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -4668,7 +4668,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -4759,7 +4759,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 10
     }
   ]
@@ -4824,7 +4824,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 20
     }
   ]
@@ -4923,7 +4923,7 @@ days    | `1d`, `2d` ... `7d`
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 10
     }
   ]
@@ -5014,7 +5014,7 @@ OCO 的状态报告与 [`orderList.status`](#查询-OCO-user_data) 相同。
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 10
     }
   ]
@@ -5118,7 +5118,7 @@ OCO 的状态报告与 [`orderList.status`](#查询-OCO-user_data) 相同。
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 10
     }
   ]
@@ -5199,7 +5199,7 @@ timestamp           | LONG   | YES          |
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 10
     }
   ]
@@ -5286,7 +5286,7 @@ timestamp           | LONG   | YES          |
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 10
     }
   ]
@@ -5346,7 +5346,7 @@ timestamp           | LONG   | YES          |
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -5394,7 +5394,7 @@ timestamp           | LONG   | YES          |
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]
@@ -5440,7 +5440,7 @@ timestamp           | LONG   | YES          |
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 1
     }
   ]

--- a/web-socket-api_CN.md
+++ b/web-socket-api_CN.md
@@ -100,7 +100,7 @@
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 321
     }
   ]
@@ -136,7 +136,7 @@
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 322
     }
   ]
@@ -237,7 +237,7 @@
       "rateLimitType": "REQUEST_WEIGHT",
       "interval": "MINUTE",
       "intervalNum": 1,
-      "limit": 1200,
+      "limit": 6000,
       "count": 70
     }
   ]


### PR DESCRIPTION
There was a missing note about the request weight from the announcements.

We have also updated the examples to match. 

However, a warning that the examples in the API documentation re: request weights, filters, permissions, should only be used as a reference to the format but not used as the source of truth.  

Please always check the Exchange Info request to confirm these details. 