### PR TITLE
fix: md path

### DIFF
--- a/rest-api.md
+++ b/rest-api.md
@@ -85,7 +85,7 @@
 * All endpoints return either a JSON object or array.
 * Data is returned in **ascending** order. Oldest first, newest last.
 * All time and timestamp related fields are in **milliseconds**.
-* For APIs that only send public market data, please use the base endpoint **https://data-api.binance.vision**. Please refer to [Market Data Only](.faqs/market_data_only.md) page.
+* For APIs that only send public market data, please use the base endpoint **https://data-api.binance.vision**. Please refer to [Market Data Only](./faqs/market_data_only.md) page.
 
 ## HTTP Return Codes
 


### PR DESCRIPTION
Fixed the path for the English version of `rest-api.md`. Unlike the Chinese version, the path to `market_data_only.md` was specified incorrectly.