### PR TITLE
[Fixing ]Clarifications on the querying commissions

### DIFF
--- a/rest-api.md
+++ b/rest-api.md
@@ -2007,19 +2007,19 @@ With `computeCommissionRates`
 
 ```javascript
 {
-  "standardCommissionForOrder": {   //Commission rates for the order depending on its role (e.g. maker or taker)
+  "standardCommissionForOrder": {  //Standard commission rates on trades from the order.
     "maker": "0.00000112",
     "taker": "0.00000114",
   },
-  "taxCommissionForOrder": {        //Tax deduction rates for the order depending on its role (e.g. maker or taker)
+  "taxCommissionForOrder": {       //Tax commission rates for trades from the order.
     "maker": "0.00000112",
     "taker": "0.00000114",
   },
-  "discount": {                     //Discount on standard commissions when paying in BNB.
+  "discount": {                    //Discount on standard commissions when paying in BNB.
     "enabledForAccount": true,
     "enabledForSymbol": true,
     "discountAsset": "BNB",
-    "discount": "0.25"             //Standard commission is reduced by this rate when paying in BNB.
+    "discount": "0.25000000"       //Standard commission is reduced by this rate when paying commission in BNB.
   }
 }
 ```
@@ -3049,11 +3049,11 @@ With `computeCommissionRates`
 
 ```javascript
 {
-  "standardCommissionForOrder": {  //Commission rates for the order depending on its role (e.g. maker or taker)
+  "standardCommissionForOrder": {  //Standard commission rates on trades from the order.
     "maker": "0.00000112",
     "taker": "0.00000114",
   },
-  "taxCommissionForOrder": {       //Tax deduction rates for the order depending on its role (e.g. maker or taker)
+  "taxCommissionForOrder": {       //Tax commission rates for trades from the order
     "maker": "0.00000112",
     "taker": "0.00000114",
   },
@@ -3061,7 +3061,7 @@ With `computeCommissionRates`
     "enabledForAccount": true,
     "enabledForSymbol": true,
     "discountAsset": "BNB",
-    "discount": "0.25"             //Standard commission is reduced by this rate when paying in BNB.
+    "discount": "0.25000000"       //Standard commission is reduced by this rate when paying commission in BNB.
   }
 }
 ```
@@ -3379,13 +3379,13 @@ Database
 ```javascript
 {
   "symbol": "BTCUSDT",
-  "standardCommission": {          //Commission rates for the order depending on its role
+  "standardCommission": {         //Commission rates on trades from the order.
     "maker": "0.00000010",
     "taker": "0.00000020",
     "buyer": "0.00000030",
     "seller": "0.00000040" 
   },
-  "taxCommission": {              //Tax rates for the order depending on its role
+  "taxCommission": {              //Tax commission rates for trades from the order.
     "maker": "0.00000112",
     "taker": "0.00000114",
     "buyer": "0.00000118",
@@ -3395,7 +3395,7 @@ Database
     "enabledForAccount": true,
     "enabledForSymbol": true,
     "discountAsset": "BNB",
-    "discount": "0.25"            //Standard commission is reduced by this rate when paying in BNB.
+    "discount": "0.25000000"      //Standard commission is reduced by this rate when paying commission in BNB.
   }
 }
 ```

--- a/rest-api_CN.md
+++ b/rest-api_CN.md
@@ -1933,11 +1933,11 @@ computeCommissionRates | BOOLEAN      | NO           | 默认值: `false`
 
 ```javascript
 {
-  "standardCommissionForOrder": {   // 根据订单的角色（例如，Maker或Taker）确定的佣金费率
+  "standardCommissionForOrder": {   // 订单交易的标准佣金率
     "maker": "0.00000112",
     "taker": "0.00000114",
   },
-  "taxCommissionForOrder": {        // 根据订单的角色（例如，Maker或Taker）确定的税收扣除率
+  "taxCommissionForOrder": {        // 订单交易的税率
     "maker": "0.00000112",
     "taker": "0.00000114",
   },
@@ -1945,7 +1945,7 @@ computeCommissionRates | BOOLEAN      | NO           | 默认值: `false`
     "enabledForAccount": true,
     "enabledForSymbol": true,
     "discountAsset": "BNB",
-    "discount": "0.25"             // 以BNB支付时，标准佣金按此比率折扣。
+    "discount": "0.25000000"        // 当用BNB支付佣金时，在标准佣金上按此比率打折
   }
 }
 
@@ -2905,11 +2905,11 @@ computeCommissionRates | BOOLEAN      | NO            | 默认值: `false`
 
 ```javascript
 {
-  "standardCommissionForOrder": {  // 根据订单的角色（例如，Maker或Taker）确定的佣金费率。
+  "standardCommissionForOrder": {  // 订单交易的标准佣金率。
     "maker": "0.00000112",
     "taker": "0.00000114",
   },
-  "taxCommissionForOrder": {       // 根据订单的角色（例如，Maker或Taker）确定的税收扣除率。
+  "taxCommissionForOrder": {       // 订单交易的税率。
     "maker": "0.00000112",
     "taker": "0.00000114",
   },
@@ -2917,7 +2917,7 @@ computeCommissionRates | BOOLEAN      | NO            | 默认值: `false`
     "enabledForAccount": true,
     "enabledForSymbol": true,
     "discountAsset": "BNB",
-    "discount": "0.25"             // 以BNB支付时，标准佣金按此比率折扣。
+    "discount": "0.25000000"       // 当用BNB支付佣金时，在标准佣金上按此比率打折。
   }
 }
 ```
@@ -3226,13 +3226,13 @@ symbol        | STRING | YES          |
 ```javascript
 {
   "symbol": "BTCUSDT",
-  "standardCommission": {          // 根据订单角色的不同，订单的佣金费率。
+  "standardCommission": {          // 订单交易的标准佣金率。
     "maker": "0.00000010",
     "taker": "0.00000020",
     "buyer": "0.00000030",
     "seller": "0.00000040" 
   },
-  "taxCommission": {              // 根据订单的角色，订单的税收扣除率。
+  "taxCommission": {              // 订单交易的税率。
     "maker": "0.00000112",
     "taker": "0.00000114",
     "buyer": "0.00000118",
@@ -3242,7 +3242,7 @@ symbol        | STRING | YES          |
     "enabledForAccount": true,
     "enabledForSymbol": true,
     "discountAsset": "BNB",
-    "discount": "0.25"            // 以BNB支付时，标准佣金按此比率折扣。
+    "discount": "0.2500000"       // 当用BNB支付佣金时，在标准佣金上按此比率打折。
   }
 }
 ```

--- a/web-socket-api.md
+++ b/web-socket-api.md
@@ -3410,19 +3410,19 @@ With `computeCommissionRates`:
   "id": "6ffebe91-01d9-43ac-be99-57cf062e0e30",
   "status": 200,
   "result": {
-    "standardCommissionForOrder": {           //Commission rates for the order depending on its role (e.g. maker or taker)
+    "standardCommissionForOrder": {           //Standard commission rates on trades from the order.
       "maker": "0.00000112",
       "taker": "0.00000114"
     },
-    "taxCommissionForOrder": {                 //Tax rates for the order depending on its role (e.g. maker or taker)
+    "taxCommissionForOrder": {                //Tax commission rates for trades from the order
       "maker": "0.00000112",
       "taker": "0.00000114"
     },  
-    "discount": {                              //Discount on standard commissions when paying in BNB.
+    "discount": {                             //Discount on standard commissions when paying in BNB.
       "enabledForAccount": true,
       "enabledForSymbol": true,
       "discountAsset": "BNB",
-      "discount": "0.25"                       //Standard commission is reduced by this rate when paying in BNB.
+      "discount": "0.25000000"                //Standard commission is reduced by this rate when paying in BNB.
     }
   },
   "rateLimits": [
@@ -6033,14 +6033,14 @@ Database
   [
     {
       "symbol": "BTCUSDT",
-      "standardCommission":               //Commission rates for the order depending on its role (e.g. maker or taker)
+      "standardCommission":              //Standard commission rates on trades from the order.
       {
         "maker": "0.00000010",
         "taker": "0.00000020",
         "buyer": "0.00000030",
         "seller": "0.00000040"
       },
-      "taxCommission":                   //Tax deduction rates for the order depending on its role (e.g. maker or taker)
+      "taxCommission":                   //Tax commission rates on trades from the order.
       {
         "maker": "0.00000112",
         "taker": "0.00000114",
@@ -6052,7 +6052,7 @@ Database
         "enabledForAccount": true,
         "enabledForSymbol": true,
         "discountAsset": "BNB",
-        "discount": "0.25"               //Standard commission is reduced by this rate when paying in BNB.
+        "discount": "0.25000000"         //Standard commission is reduced by this rate when paying commission in BNB.
       }
     }
   ],

--- a/web-socket-api_CN.md
+++ b/web-socket-api_CN.md
@@ -3290,7 +3290,7 @@ NONE
       "enabledForAccount": true,
       "enabledForSymbol": true,
       "discountAsset": "BNB",
-      "discount": "0.25"                       // 以BNB支付时，标准佣金按此比率折扣。
+      "discount": "0.25000000"                 // 当用BNB支付佣金时，在标准佣金上按此比率打折。
     }
   },
   "rateLimits": [
@@ -5191,11 +5191,11 @@ NONE
   "id": "3a4437e2-41a3-4c19-897c-9cadc5dce8b6",
   "status": 200,
   "result": {
-    "standardCommissionForOrder": {                // 根据订单的角色（例如，Maker或Taker）确定的佣金费率。
+    "standardCommissionForOrder": {                // 订单交易的标准佣金率。
       "maker": "0.00000112",
       "taker": "0.00000114"
     },
-    "taxCommissionForOrder": {                     // 根据订单的角色（例如，Maker或Taker）确定的税收扣除率。
+    "taxCommissionForOrder": {                     // 订单交易的税率。
       "maker": "0.00000112",
       "taker": "0.00000114"
     },
@@ -5203,7 +5203,7 @@ NONE
       "enabledForAccount": true,
       "enabledForSymbol": true,
       "discountAsset": "BNB",
-      "discount": "0.25"                           // 以BNB支付时，标准佣金按此比率减少。
+      "discount": "0.25000000"                     // 当用BNB支付佣金时，在标准佣金上按此比率打折。
     }
   },
   "rateLimits": [
@@ -5877,14 +5877,14 @@ timestamp           | LONG   | YES          |
   [
     {
       "symbol": "BTCUSDT",
-      "standardCommission":               // 根据订单的角色（例如，Maker或Taker）确定的佣金费率。
+      "standardCommission":               // 订单交易的标准佣金率。
       {
         "maker": "0.00000010",
         "taker": "0.00000020",
         "buyer": "0.00000030",
         "seller": "0.00000040"
       },
-      "taxCommission":                   // 根据订单的角色（例如，Maker或Taker）确定的税收扣除率。
+      "taxCommission":                   // 订单交易的税率。
       {
         "maker": "0.00000112",
         "taker": "0.00000114",
@@ -5896,7 +5896,7 @@ timestamp           | LONG   | YES          |
         "enabledForAccount": true,
         "enabledForSymbol": true,
         "discountAsset": "BNB",
-        "discount": "0.25"               // 以BNB支付时，标准佣金按此比率减少。
+        "discount": "0.25000000"         // 当用BNB支付佣金时，在标准佣金上按此比率打折。
       }
     }
   ],


### PR DESCRIPTION
There was some confusion re: commission where users might think that commission is paid through an order, or only paid if the order is ONLY fully filled.

We have adjusted the wording for clarity. 

Thank you. 
