### PR TITLE
Explaining Commissions on SPOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Name | Description
 Name | Description
 ------------ | ------------
 [spot_glossary](./faqs/spot_glossary.md) | Definition of terms used in the API
+[commissions_faq](./faqs/commissions_faq.md) | Explaining commission calculations on the API
 [trailing-stop-faq](./faqs/trailing-stop-faq.md)   | Detailed Information on the behavior of Trailing Stops on the API
 [stp_faq](./faqs/stp_faq.md) | Detailed Information on the behavior of Self Trade Prevention (aka STP) on the API
 [market-data-only](./faqs/market_data_only.md) | Information on our market data only API and websocket streams.

--- a/README_CN.md
+++ b/README_CN.md
@@ -28,7 +28,8 @@
 
 名称 | 描述
 ------------ | ------------
-[spot_glossary_cn](./faqs/spot_glossary_cn.md) | 现货交易API术语表
+[spot_glossary_cn](./faqs/spot_glossary_cn.md) | 现货交易 API 术语表
+[commissions_faq_cn](./faqs/commissions_faq_cn.md) | 解释 API 上所使用的佣金计算方式
 [trailing_stop_faq_cn](./faqs/trailing-stop-faq-cn.md)   | 追踪止盈止损订单(Trailing Stop)详细信息和常见问题
 [stp_faq_cn](./faqs/stp_faq_cn.md) | 关于 Self Trade Prevention (STP) 的详细信息
 [market_data_only_cn](./faqs/market_data_only_cn.md) | 仅提供市场数据的 API 和 Websocket Streams

--- a/faqs/commission_faq.md
+++ b/faqs/commission_faq.md
@@ -1,0 +1,151 @@
+# Commission Rates
+
+**Disclaimer:** 
+
+* The commissions and prices used here are fictional, and do not imply anything about the actual setup on the live exchange. 
+* This applies only for the SPOT Exchange.
+
+## What are Commission Rates?
+
+These are the rates that determine the commission to be paid on trades when your order fills for any amount.
+
+## What are the different types of rates?
+
+There are 3 types:
+
+* `standardCommission` - Standard commission rates on trades from the order.
+* `taxCommission` - Tax commission rates on trades from the order.
+* `discount` - Discount rate on standard commission if paying the commission with BNB.
+
+## How do I know what the commission rates are?
+
+You can find them using the following requests:
+
+REST API: `GET /api/v3/account/commission`
+
+WebSocket API: `account.commission`
+
+You can also find out the commission rates to a trade from an order using the test order requests with `computeCommissionRates`.
+
+## What is the difference between the response sending a test order with `computeCommissionRates` vs the response from querying commission rates?
+
+This is an example of the former:
+
+```json
+{
+  "standardCommissionForOrder": {
+    "maker": "0.00000050",
+    "taker": "0.00000060"
+  },
+  "taxCommissionForOrder": {
+    "maker": "0.00000228",
+    "taker": "0.00000230"
+  },
+  "discount": {
+    "enabledForAccount": true,
+    "enabledForSymbol": true,
+    "discountAsset": "BNB",
+    "discount": "0.25000000"
+  }
+}
+```
+
+When using the order test request using `computeCommissionRates`, the `standardCommissionForOrder`  and `taxCommissionForOrder` shows the actual commission rate for trades from that order. Both `maker` and `taker` rates are returned regardless of the order parameters. 
+
+The response for query commission rates gives the current commission rate for that symbol for your account.
+
+## How is the commission calculated?
+
+Using an example commission configuration: 
+
+```json
+{
+  "symbol": "BTCUSDT",
+  "standardCommission": {
+    "maker": "0.00000010",
+    "taker": "0.00000020",
+    "buyer": "0.00000030",
+    "seller": "0.00000040" 
+  },
+  "taxCommission": {
+    "maker": "0.00000112",
+    "taker": "0.00000114",
+    "buyer": "0.00000118",
+    "seller": "0.00000116" 
+  },
+  "discount": {
+    "enabledForAccount": true,
+    "enabledForSymbol": true,
+    "discountAsset": "BNB",
+    "discount": "0.25000000" 
+  }
+}
+```
+
+If you placed an order with the following parameters which took immediately and fully filled in a single trade:
+
+|Parameter| Value|
+|---      | ---  |
+|symbol   |BTCUSDT|
+|price    |35,000|
+|quantity |0.49975|
+|side     |SELL   |
+|type     |MARKET |
+
+Since you sold BTC for USDT, the commission will be paid either in USDT or BNB. 
+
+When standard commission is calculated, the received amount is multiplied with the sum of the rates. 
+
+Since this order is on the `SELL` side, the received amount is the notional value. (For orders on the `BUY` side, the received amount would be `quantity`.)
+The order type was `MARKET`, making this the taker order for the trade.
+
+```
+Standard Commission = Notional value * (taker + seller)
+                    = (35000 * 0.49975) * (0.00000020 + 0.00000040)
+                    = 17491.25000000 * 0.00000060
+                    = 0.01049475 USDT
+```
+
+Tax commission (if applicable) is calculated similarly: 
+
+```
+Tax commission = Notional value * (taker + seller)
+               = (35000 * 0.49975) * (0.00000114 + 0.00000116)
+               = 17491.25000000 * 0.00000230
+               = 0.04022988 USDT
+```
+
+If not paying in BNB, the total commission are summed up and deducted from your received amount of `USDT`.
+
+Since `enabledforAccount` and `enabledForSymbol` under `discount` is set to `true`, this means the commission will be paid in BNB assuming you have a sufficient balance.
+
+If paying with BNB, then the standard commission will be reduced based on the `discount`.
+
+First the standard commission and tax commission will be converted into BNB based on the exchange rate. For this example, assume that 1 BNB = 260 USDT.
+
+```
+Standard commission (Discounted and in BNB) = (Standard commission * BNB exchange rate) * discount
+                                            = (0.01049475 * 1/260) * 0.25
+                                            = 0.000040364 * 0.25
+                                            = 0.000010091
+```
+
+Note that the discount **does not apply to tax commissions**.
+
+```
+Tax Commission (in BNB) = Tax commission * BNB exchange rate
+                        = 0.04022988 * (1/260)
+                        = 0.00015473
+```
+
+```
+Total Commission (in BNB) = Standard commission (Discounted) + Tax commission (in BNB)
+                          = 0.000010091 + 0.00015473
+                          = 0.00016482
+```
+
+If you do not have enough BNB to pay the discounted commission, the full commission will be taken out of your received amount of USDT instead.
+
+
+
+

--- a/faqs/commission_faq_cn.md
+++ b/faqs/commission_faq_cn.md
@@ -1,0 +1,153 @@
+# 佣金率
+
+**免责声明：**
+
+* 本文所用的佣金和价格都是虚构的，并不代表现实交易中的设置。
+* 本内容只适用于现货交易所。
+
+## 什么是佣金率？
+
+这些比率是用来决定当您的任何金额订单成交后，您所需要支付的佣金金额数目。
+
+## 佣金率有哪些不同的类型？
+
+有以下3种类型：
+
+* 标准佣金（`standardCommission`） - 来自订单的标准交易佣金率。
+* 税务佣金（`taxCommission`） - 来自订单的税费佣金率。
+* 折扣（`discount`） - 如果使用`BNB`支付佣金，在标准佣金基础上可以得到的折扣率。
+
+## 我怎么才能知道佣金率是多少？
+
+您可以通过以下请求找到它们：
+
+REST API: `GET /api/v3/account/commission`
+
+WebSocket API: `account.commission`
+
+您也可以通过在测试订单请求中使用 `computeCommissionRates` 来找出订单交易的佣金比率。
+
+## 在发送测试订单中使用`computeCommissionRates`得到的响应与查询佣金率的响应之间有什么不同？
+
+以下是有关前者的一个例子：
+
+
+```json
+{
+  "standardCommissionForOrder": {
+    "maker": "0.00000050",
+    "taker": "0.00000060"
+  },
+  "taxCommissionForOrder": {
+    "maker": "0.00000228",
+    "taker": "0.00000230"
+  },
+  "discount": {
+    "enabledForAccount": true,
+    "enabledForSymbol": true,
+    "discountAsset": "BNB",
+    "discount": "0.25000000"
+  }
+}
+```
+
+当使用带有`computeCommissionRates`的订单测试请求时，`standardCommissionForOrder` 和 `taxCommissionForOrder` 显示了该订单交易的实际佣金率。无论订单参数如何设置，响应均会返回`maker`和`taker`的费率。
+
+而查询佣金率的响应则提供了针对于您的帐户中该交易对的当前佣金率。
+
+
+## 佣金是怎么计算的？
+
+以下面的这个佣金配置为例：
+
+```json
+{
+  "symbol": "BTCUSDT",
+  "standardCommission": {
+    "maker": "0.00000010",
+    "taker": "0.00000020",
+    "buyer": "0.00000030",
+    "seller": "0.00000040" 
+  },
+  "taxCommission": {
+    "maker": "0.00000112",
+    "taker": "0.00000114",
+    "buyer": "0.00000118",
+    "seller": "0.00000116" 
+  },
+  "discount": {
+    "enabledForAccount": true,
+    "enabledForSymbol": true,
+    "discountAsset": "BNB",
+    "discount": "0.25000000" 
+  }
+}
+```
+
+如果您使用了下列参数来下一个订单，该订单立即执行并通过一次交易就全部成交：
+
+|参数      | 取值 |
+|---      | ---  |
+|symbol   |BTCUSDT|
+|price    |35,000|
+|quantity |0.49975|
+|side     |SELL   |
+|type     |MARKET |
+
+由于您卖出了 `BTC` 来换取 `USDT` ，佣金将以 `USDT` 或 `BNB` 形式支付。
+
+在计算标准佣金（`standard commission`）时，所接收的金额会与费率之和相乘。
+
+由于此订单在`卖方` （`SELL`）一侧，所接收的金额是`名义价值` （`notional value`）。 对于`买方` （`BUY`）一侧的订单，所接收的金额则是`数量` （`quantity`）。
+因为订单类型为`市价` （`MARKET`）的关系，使得此订单成为交易的`吃单方` （`taker`）。
+
+```
+标准佣金 = 名义价值 * (taker + seller)
+                    = (35000 * 0.49975) * (0.00000020 + 0.00000040)
+                    = 17491.25000000 * 0.00000060
+                    = 0.01049475 USDT
+```
+
+如果适用，税务佣金（`tax commission`）的计算方式类似于标准佣金：
+
+```
+税务佣金 = 名义价值 * (taker + seller)
+               = (35000 * 0.49975) * (0.00000114 + 0.00000116)
+               = 17491.25000000 * 0.00000230
+               = 0.04022988 USDT
+```
+
+如果您不使用`BNB`支付佣金，佣金总数会被加起来并从您所接收的`USDT`金额中扣除。
+
+由于`discount`下的`enabledforAccount`和`enabledForSymbol`被设置为`true`，这意味着如果您所持有的余额足够，那么佣金将用`BNB`支付。
+
+如果用`BNB`支付，那么基于折扣（`discount`），您所需要支付的标准佣金将会减少。
+
+首先，标准佣金和税务佣金将根据汇率转换成`BNB`。在这个例子中，假设1 BNB = 260 USDT。
+
+```
+标准佣金(打折后以BNB支付) = (标准佣金 * BNB 汇率) * 折扣
+                                            = (0.01049475 * 1/260) * 0.25
+                                            = 0.000040364 * 0.25
+                                            = 0.000010091
+```
+
+请注意，折扣（`discount`）**不适用于税务佣金（`税务佣金`）**。
+
+```
+税务佣金 (以BNB支付) = 税务佣金 * BNB 汇率
+                        = 0.04022988 * (1/260)
+                        = 0.00015473
+```
+
+```
+佣金总数 (以BNB支付) = 标准佣金(打折后) + 税务佣金 (以BNB支付)
+                          = 0.000010091 + 0.00015473
+                          = 0.00016482
+```
+
+如果您的`BNB`余额不足以支付折扣后的佣金，那么全部佣金将从您所接收的`USDT`金额中扣除。
+
+
+
+


### PR DESCRIPTION
With the new requests on how to query commissions in your account, a supplementary documentation has been added to explain how to understand the rates with some examples. 