### PR TITLE
leave the signature as utf-8 string

### DIFF
--- a/rest-api.md
+++ b/rest-api.md
@@ -428,7 +428,7 @@ params['timestamp'] = timestamp
 # Sign the request
 payload = '&'.join([f'{param}={value}' for param, value in params.items()])
 signature = base64.b64encode(private_key.sign(payload.encode('ASCII')))
-params['signature'] = signature
+params['signature'] = signature.decode()
 
 # Send the request
 headers = {


### PR DESCRIPTION
Certain http clients (like httpx) can leave a atring preceded by "b'" in the signature param, raising an invalid signature error