### PR TITLE
Clarified SBE support on SPOT Testnet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ The SPOT WebSocket API can now support SBE on [SPOT Testnet](https://testnet.bin
 
 The SBE schema has been updated with WebSocket API metadata without incrementing either `schemaId` or `version`.
 
-Users using only the REST API may continue to use the SBE schema with git commit hash [`128b94b2591944a536ae427626b795000100cf1d`](https://github.com/binance/binance-spot-api-docs/blob/128b94b2591944a536ae427626b795000100cf1d/sbe/schemas/spot_1_0.xml) or update to the newly-committed SBE schema.
+Users using SBE only on the REST API may continue to use the SBE schema with git commit hash [`128b94b2591944a536ae427626b795000100cf1d`](https://github.com/binance/binance-spot-api-docs/blob/128b94b2591944a536ae427626b795000100cf1d/sbe/schemas/spot_1_0.xml) or update to the newly-published SBE schema.
 
-Users who want to use the WebSocket API must use the [newly-committed SBE schema](https://github.com/binance/binance-spot-api-docs/blob/becd4d44a09d94821d2dc761ba9197aae8b495c3/sbe/schemas/spot_1_0.xml).
+Users who want to use SBE on the WebSocket API must use the [newly-published SBE schema](https://github.com/binance/binance-spot-api-docs/blob/becd4d44a09d94821d2dc761ba9197aae8b495c3/sbe/schemas/spot_1_0.xml).
 
 The [FAQ](./faqs/sbe_faq.md) for SBE has been updated.
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -18,7 +18,7 @@
 
 SBE 模式已经更新了 WebSocket API 元数据，但并没有增加 `schemaId` 或者 `version`。
 
-仅在 REST API 上使用 SBE 的用户可以继续使用 SBE 模式 [`128b94b2591944a536ae427626b795000100cf1d`](https://github.com/binance/binance-spot-api-docs/blob/128b94b2591944a536ae427626b795000100cf1d/sbe/schemas/spot_1_0.xml)，或者更新到新提交的 SBE 模式。
+* 仅在 REST API 上使用 SBE 的用户可以继续使用 SBE 模式 [`128b94b2591944a536ae427626b795000100cf1d`](https://github.com/binance/binance-spot-api-docs/blob/128b94b2591944a536ae427626b795000100cf1d/sbe/schemas/spot_1_0.xml)，或者更新到新提交的 SBE 模式。
 
 * 希望在 WebSocket API 上使用 SBE 的用户，需要更新到[最新的 SBE 模式](https://github.com/binance/binance-spot-api-docs/blob/becd4d44a09d94821d2dc761ba9197aae8b495c3/sbe/schemas/spot_1_0.xml)。
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -18,9 +18,9 @@
 
 SBE 模式已经更新了 WebSocket API 元数据，但并没有增加 `schemaId` 或者 `version`。
 
-* 仅使用 REST API 的用户可以继续使用带有 git 提交哈希[`128b94b2591944a536ae427626b795000100cf1d`](https://github.com/binance/binance-spot-api-docs/commit/128b94b2591944a536ae427626b795000100cf1d/sbe/schemas/spot_1_0.xml)的SBE模式，或者更新到新提交的SBE模式。
+仅在 REST API 上使用 SBE 的用户可以继续使用 SBE 模式 [`128b94b2591944a536ae427626b795000100cf1d`](https://github.com/binance/binance-spot-api-docs/blob/128b94b2591944a536ae427626b795000100cf1d/sbe/schemas/spot_1_0.xml)，或者更新到新提交的 SBE 模式。
 
-* 希望使用 WebSocket API 的用户，需要更新到最新的 SBE 模式，git 提交哈希 [`becd4d44a09d94821d2dc761ba9197aae8b495c3`](https://github.com/binance/binance-spot-api-docs/blob/becd4d44a09d94821d2dc761ba9197aae8b495c3/sbe/schemas/spot_1_0.xml)。
+* 希望在 WebSocket API 上使用 SBE 的用户，需要更新到[最新的 SBE 模式](https://github.com/binance/binance-spot-api-docs/blob/becd4d44a09d94821d2dc761ba9197aae8b495c3/sbe/schemas/spot_1_0.xml)。
 
 SBE 的 [FAQ](./faqs/sbe_faq_cn.md) 已经更新。
 


### PR DESCRIPTION
There was some confusion that SPOT testnet could only support SBE using the WebSocket API.

To clarify, SPOT Testnet currently can support SBE for both the REST and the WebSocket API.

Support will remain for users who still want to receive the JSON responses on either API on Testnet.

This will be the same behavior on the live exchange. 

