### PR TITLE
Added clarification on the weight changes for trades requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ General changes:
 
 * `GET /api/v3/account` has a new optional parameter `omitZeroBalances`, which if enabled hides all zero balances.
 * `account.status` has a new optional parameter `omitZeroBalances` which if enabled hides all zero balances.
-* **The weight of the following requests has been increased from 10 to 25**:
+* **The weight of the following requests has been increased from 10 to 25 (This will take effect on April 3, 2024)**:
     * `GET /api/v3/trades`
     * `GET /api/v3/historicalTrades`
     * `trades.recent`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ General changes:
 
 * `GET /api/v3/account` has a new optional parameter `omitZeroBalances`, which if enabled hides all zero balances.
 * `account.status` has a new optional parameter `omitZeroBalances` which if enabled hides all zero balances.
-* **The weight of the following requests has been increased from 10 to 25 (This will take effect on April 3, 2024)**:
+* **The weight of the following requests has been increased from 10 to 25 (This will take effect on April 4, 2024)**:
     * `GET /api/v3/trades`
     * `GET /api/v3/historicalTrades`
     * `trades.recent`

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -7,7 +7,7 @@
 
 * `GET /api/v3/account` 新加可选参数 `omitZeroBalances`，如果启用，则会隐藏所有零余额。
 * `account.status` 新加可选参数 `omitZeroBalances`，如果启用，则会隐藏所有零余额。
-* **以下请求的权重已从 10 增加到 25**：
+* **以下请求的权重已从 10 增加到 25 （该规定将于2024年4月4日生效）**：
     * `GET /api/v3/trades`
     * `GET /api/v3/historicalTrades`
     * `trades.recent`


### PR DESCRIPTION
There were some concerns about the sudden weight changes to the trades requests.

This will take effect on April 4, 2024.

Note that since we are deploying these live, you may not see the weight changes right away. 
