### PR TITLE
Fixed local order book lastUpdatedId logic

### DIFF
--- a/web-socket-streams.md
+++ b/web-socket-streams.md
@@ -588,14 +588,14 @@ Order book price and quantity depth updates used to locally manage an order book
 1. Open a WebSocket connection to `wss://stream.binance.com:9443/ws/bnbbtc@depth`.
 1. Buffer the events received from the stream. Note the `U` of the first event you received.
 1. Get a depth snapshot from `https://api.binance.com/api/v3/depth?symbol=BNBBTC&limit=5000`.
-1. If the `lastUpdateId` from the snapshot is strictly less than the `U` from step 2, go back to step 3.
+1. If the `lastUpdateId` from the snapshot is < than the `U` from step 2, go back to step 3.
 1. In the buffered events, discard any event where `u` is <= `lastUpdateId` of the snapshot. The first buffered event should now have `lastUpdateId` within its `[U;u]` range.
 1. Set your local order book to the snapshot. Its update ID is `lastUpdateId`.
 1. Apply the update procedure below to all buffered events, and then to all subsequent events received.
 
 To apply an event to your local order book, follow this update procedure:
-1. If the event `u` (last update ID) is < the update ID of your local order book, ignore the event.
-1. If the event `U` (first update ID) is > the update ID of your local order book, something went wrong. Discard your local order book and restart the process from the beginning.
+1. If the event `u` (last update ID) is <= the update ID of your local order book, ignore the event.
+1. If the event `U` (first update ID) is > (the update ID of your local order book + 1), something went wrong. Discard your local order book and restart the process from the beginning.
 1. For each price level in bids (`b`) and asks (`a`), set the new quantity in the order book:
     * If the price level does not exist in the order book, insert it with new quantity.
     * If the quantity is zero, remove the price level from the order book.


### PR DESCRIPTION
The docs are incorrect. It says that if first update id > last update id, then it's corrupt.

The thing is, the first update id is always an increment (+1) from the last update id.
