### PR TITLE
Add community-maintained R connector resource: binxr

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Please refer to [CHANGELOG](./CHANGELOG.md) for latest changes on our APIs and S
         * [PHP](https://github.com/binance/binance-connector-php)
         * [Go](https://github.com/binance/binance-connector-go)
         * [TypeScript](https://github.com/binance/binance-connector-typescript)
+        * [R](https://github.com/OliverLDS/binxr)
 * FIX Connector - This provides access to the exchange using the FIX protocol.
     * [Python](https://github.com/binance/binance-fix-connector-python)
 * [Swagger](https://github.com/binance/binance-api-swagger)


### PR DESCRIPTION
This PR proposes adding `binxr` as a community-maintained R connector resource.

CRAN: https://cran.r-project.org/web/packages/binxr/index.html
GitHub: https://github.com/OliverLDS/binxr
Docs: https://oliverlds.github.io/binxr/

I understand this should not be described as an official Binance SDK unless Binance chooses to review and approve it as such.